### PR TITLE
Add github url to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
   description='Simple integration of Cross-Site Request Forgery (XSRF) Protection by using either Cookies or Context combined with Headers',
   py_modules=['fastapi_csrf_protect'],
   package_dir={'': 'fastapi_csrf_protect'},
+  url='https://github.com/aekazitt/fastapi-csrf-protect',
   classifiers=[
     'Environment :: Web Environment',
     'Intended Audience :: Developers',


### PR DESCRIPTION
So pypi (https://pypi.org/project/fastapi-csrf-protect/ ) links to github as the project Homepage.

I had to search github based on your pypi username to find the repo, this should make it a lot easier to find.
